### PR TITLE
Update balance_delta.py

### DIFF
--- a/algofi_amm/v0/balance_delta.py
+++ b/algofi_amm/v0/balance_delta.py
@@ -17,7 +17,7 @@ class BalanceDelta():
         self.asset2_delta = asset2_delta
         self.lp_delta = lp_delta
 
-        if (lp_delta == 0):
+        if (lp_delta != 0):
             self.price_delta = 0
         elif (pool.lp_circulation == 0):
             self.price_delta = 0


### PR DESCRIPTION
As it is now, Pool.get_swap_for_exact_quote() and Pool.get_swap_exact_for_quote() always return BalanceDelta with price_delta = 0. And Pool.get_pool_quote/burn_quote returns small non-zero values for price_delta.