### PR TITLE
Fixed Keyerror: 'p' when pool status is not ACTIVE

### DIFF
--- a/algofi_amm/v0/pool.py
+++ b/algofi_amm/v0/pool.py
@@ -63,6 +63,9 @@ class Pool:
             else:
                 self.pool_status = PoolStatus.ACTIVE
                 self.application_id = self.nanoswap_pools[key]
+                self.address = get_application_address(self.application_id)
+                self.init_state()
+                self.refresh_state()
 
         else:
             self.logic_sig = LogicSigAccount(generate_logic_sig(asset1.asset_id, asset2.asset_id, self.manager_application_id, self.validator_index))
@@ -78,10 +81,14 @@ class Pool:
                         (logic_sig_local_state[manager_strings.registered_asset_2_id] != asset2.asset_id) or \
                         (logic_sig_local_state[manager_strings.validator_index] != self.validator_index):
                     raise Exception("Logic sig state does not match as expected")
-            self.application_id = logic_sig_local_state[manager_strings.registered_pool_id]
+                self.application_id = logic_sig_local_state[manager_strings.registered_pool_id]
+                self.address = get_application_address(self.application_id)
+                self.init_state()
+                self.refresh_state()
 
-        self.address = get_application_address(self.application_id)
-
+    def init_state(self):
+        """Get global state
+        """
         # get global state
         pool_state = get_application_global_state(self.algod, self.application_id)
         self.lp_asset_id = pool_state[pool_strings.lp_id]
@@ -90,8 +97,6 @@ class Pool:
         self.flash_loan_fee = pool_state[pool_strings.flash_loan_fee]
         self.max_flash_loan_ratio = pool_state[pool_strings.max_flash_loan_ratio]
 
-        # refresh state
-        self.refresh_state()
 
     def refresh_metadata(self):
         """Refresh the metadata of the pool (e.g. if now initialized)
@@ -114,13 +119,7 @@ class Pool:
 
         self.address = get_application_address(self.application_id)
 
-        # get global state
-        pool_state = get_application_global_state(self.algod, self.application_id)
-        self.lp_asset_id = pool_state[pool_strings.lp_id]
-        self.admin = pool_state[pool_strings.admin]
-        self.reserve_factor = pool_state[pool_strings.reserve_factor]
-        self.flash_loan_fee = pool_state[pool_strings.flash_loan_fee]
-        self.max_flash_loan_ratio = pool_state[pool_strings.max_flash_loan_ratio]
+        self.init_state()
 
     def refresh_state(self):
         """Refresh the global state of the pool


### PR DESCRIPTION
:gift_heart: 
this line 81 below raises an exception (Keyerror: 'p') and before non ACTIVE pools didnt raise any exception, and just leave the status of the pool object as UNINITIALIZED

https://github.com/Algofiorg/algofi-amm-py-sdk/blob/7586b9bfdd2f66485389cee09260f38050024215/algofi_amm/v0/pool.py#L81

after this PR, the exception on UNINITIALIZED pools doesn't happens anymore, and pool objects are initialized with status UNINITIALIZED again (less than nano pools that have an implicit `raise Exception("Nanoswap pool does not exist")`); also killed the duplicated code inside `refresh_metadata()`

:koala: in any case, let me comment that makes no sense to me that nano pools raise exceptions and other pools set statuses. why you dont put UNINITIALIZED status on nano pools too instead of raising an exception (like on any other pool)? (is a question for your consideration :P not to be answered)

aalso, you could set the default fees to 10000 instead of 2000 if the pool type is NANOSWAP (on `get_pool_txns`, `get_swap_exact_for_txns` and `get_swap_for_exact_txns`), cos having always a default of 2000 is wrong now
i was lazy and just did `params.fee = fee if self.pool_type != PoolType.NANOSWAP else 10000`, so no PR fixing default fees

# in Owen we trust