### PR TITLE
Api endpoint patch

### DIFF
--- a/algofi_amm/v0/asset.py
+++ b/algofi_amm/v0/asset.py
@@ -32,7 +32,7 @@ class Asset():
             self.unit_name = "ALGO"
             self.url = "https://www.algorand.com/"
         else:
-            asset_info = amm_client.algod.asset_info(asset_id)
+            asset_info = amm_client.indexer.asset_info(asset_id)['asset']
             self.creator = asset_info["params"]["creator"]
             self.decimals = asset_info["params"]["decimals"]
             self.default_frozen = asset_info["params"].get("default-frozen", False)

--- a/algofi_amm/v0/asset.py
+++ b/algofi_amm/v0/asset.py
@@ -32,7 +32,6 @@ class Asset():
             self.unit_name = "ALGO"
             self.url = "https://www.algorand.com/"
         else:
-
             asset_info = amm_client.indexer.asset_info(asset_id)
             self.creator = asset_info["asset"]["params"]["creator"]
             self.decimals = asset_info["asset"]["params"]["decimals"]

--- a/algofi_amm/v0/client.py
+++ b/algofi_amm/v0/client.py
@@ -85,7 +85,7 @@ class AlgofiAMMClient():
         if not address:
             address = self.user_address
         if address:
-            return self.algod.account_info(address)
+            return self.indexer.account_info(address)['account']
         else:
             raise Exception("user_address has not been specified")
 
@@ -217,7 +217,8 @@ class AlgofiAMMTestnetClient(AlgofiAMMClient):
         """
         historical_indexer_client = IndexerClient("", "https://indexer.testnet.algoexplorerapi.io/", headers={"User-Agent": "algosdk"})
         if algod_client is None:
-            algod_client = AlgodClient("", "https://api.testnet.algoexplorer.io", headers={"User-Agent": "algosdk"})
+            algod_client = AlgodClient("", "https://node.testnet.algoexplorer.io", headers={"User-Agent": "algosdk"})
+            
         if indexer_client is None:
             indexer_client = IndexerClient("", "https://algoindexer.testnet.algoexplorerapi.io", headers={"User-Agent": "algosdk"})
         super().__init__(algod_client, indexer_client=indexer_client, historical_indexer_client=historical_indexer_client, user_address=user_address, network=Network.TESTNET)
@@ -236,7 +237,7 @@ class AlgofiAMMMainnetClient(AlgofiAMMClient):
         """
         historical_indexer_client = IndexerClient("", "https://indexer.algoexplorerapi.io/", headers={"User-Agent": "algosdk"})
         if algod_client is None:
-            algod_client = AlgodClient("", "https://algoexplorerapi.io", headers={"User-Agent": "algosdk"})
+            algod_client = AlgodClient("", "https://node.algoexplorerapi.io", headers={"User-Agent": "algosdk"})
         if indexer_client is None:
             indexer_client = IndexerClient("", "https://algoindexer.algoexplorerapi.io", headers={"User-Agent": "algosdk"})
         super().__init__(algod_client, indexer_client=indexer_client, historical_indexer_client=historical_indexer_client, user_address=user_address, network=Network.MAINNET)

--- a/algofi_amm/v0/client.py
+++ b/algofi_amm/v0/client.py
@@ -218,7 +218,6 @@ class AlgofiAMMTestnetClient(AlgofiAMMClient):
         historical_indexer_client = IndexerClient("", "https://indexer.testnet.algoexplorerapi.io/", headers={"User-Agent": "algosdk"})
         if algod_client is None:
             algod_client = AlgodClient("", "https://node.testnet.algoexplorer.io", headers={"User-Agent": "algosdk"})
-            
         if indexer_client is None:
             indexer_client = IndexerClient("", "https://algoindexer.testnet.algoexplorerapi.io", headers={"User-Agent": "algosdk"})
         super().__init__(algod_client, indexer_client=indexer_client, historical_indexer_client=historical_indexer_client, user_address=user_address, network=Network.TESTNET)


### PR DESCRIPTION
You forgot to change the URL to the endpoint.
Also, changing to the indexer causes an issue when instantiating a pool object, the indexer return an error when trying to look at the LogicSigAccount local variable.
algosdk.error.IndexerHTTPError: no accounts found for address