### PR TITLE
Added __hash__ to asset to allow for Asset as a dict key

### DIFF
--- a/algofi_amm/__init__.py
+++ b/algofi_amm/__init__.py
@@ -3,5 +3,5 @@ This module contains all the relevant classes and data for interacting with the 
 """
 
 __all__ = ["v0", "contract_strings", "utils"]
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __author__ = "Algofi"

--- a/algofi_amm/v0/asset.py
+++ b/algofi_amm/v0/asset.py
@@ -53,6 +53,13 @@ class Asset():
                 "freeze": self.freeze, "manager": self.manager, "name": self.name, "reserve": self.reserve, "total": self.total,
                 "unit_name": self.unit_name, "url": self.url})
 
+    def __hash__(self) -> int:
+        """Returns an int which is the asset_id of the :class:`Asset` current object
+        :return: asset_id
+        :rtype: int
+        """
+        return self.asset_id
+
     def get_scaled_amount(self, amount):
         """Returns an integer representation of asset amount scaled by asset's decimals
         :param amount: amount of asset

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     description="Algofi AMM Python SDK",
     author="Algofi",
     author_email="founders@algofi.org",
-    version="1.1.0",
+    version="1.1.1",
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="MIT",


### PR DESCRIPTION
Added "__hash__" to the asset class to allow for it to be used as a key in dicts and other usages.
For example you can now use the Asset Object below
```
from algofi_amm.v0.client import AlgofiAMMMainnetClient
from algofi_amm.v0.asset import Asset

amm_client = AlgofiAMMMainnetClient(user_address=sender)
asset1 = Asset(amm_client, 1)
asset2 = Asset(amm_client, 42281306)
assets = {
    asset1: "Some Asset",
    asset2: "Some Asset 2"
}
```
